### PR TITLE
Do not add CRUD product routes to frontend

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Spree::Core::Engine.add_routes do
     resource :review_settings, only: [:edit, :update]
   end
 
-  resources :products do
+  resources :products, only: [] do
     resources :reviews, only: [:index, :new, :create] do
     end
   end


### PR DESCRIPTION
Before this change, all resource routes for product would be
generated when using this extension. There is two ways in which
this is bad:

1. Spree's frontend already defined :show and :index for products.
Adding :destroy is one step closer to a security issue as customers
should not be able to even start this request.

2. When overriding or changing Spree's product routes, before this changes,
the overrides won't work.