### PR TITLE
Fix install generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Now bundle up with:
 
 Next, run the rake task that copies the necessary migrations and assets to your project:
 
-    rails g spree_reviews:install
+    rails g solidus_reviews:install
 
 And finish with a migrate:
 

--- a/lib/spree_reviews/engine.rb
+++ b/lib/spree_reviews/engine.rb
@@ -2,7 +2,7 @@ module SpreeReviews
   class Engine < Rails::Engine
     require 'spree/core'
     isolate_namespace Spree
-    engine_name 'spree_reviews'
+    engine_name 'solidus_reviews'
 
     config.autoload_paths += %W(#{config.root}/lib)
 


### PR DESCRIPTION
This PR fixes the following:

* rake task should say `solidus_reviews` instead of `spree_reviews`
* db migrations weren't being copied over