### PR TITLE
Allow solidus_auth_devise < 1.5

### DIFF
--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus', '~> 1.0'
   s.add_dependency 'deface', '~> 1.0'
-  s.add_dependency 'solidus_auth_devise', '~> 1.5'
+  s.add_dependency 'solidus_auth_devise', '~> 1.0'
 
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'capybara', '~> 2.7'


### PR DESCRIPTION
By allowing smaller versions of solidus_auth_devise we allow usage of Devise 3.5 instead of 4.1