### PR TITLE
Prefix named route

### DIFF
--- a/app/overrides/add_reviews_to_admin_configuration_sidebar.rb
+++ b/app/overrides/add_reviews_to_admin_configuration_sidebar.rb
@@ -7,5 +7,5 @@ end
 Deface::Override.new(virtual_path: "spree/admin/shared/_settings_sub_menu",
                      name: "converted_admin_configurations_menu",
                      insert_bottom: "[data-hook='admin_settings_sub_tabs']",
-                     text: "<%= tab :reviews, url: edit_admin_review_settings_path, match_path: /review_settings/ %>",
+                     text: "<%= tab :reviews, url: spree.edit_admin_review_settings_path, match_path: /review_settings/ %>",
                      disabled: false)


### PR DESCRIPTION
This prefixes a named route for compatibility with controllers that exist outside the Spree namespace. Currently, an `undefined method` error is thrown if these controllers attempt to load the admin sidebar.