### PR TITLE
Add user email to admin review editing page

### DIFF
--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -33,4 +33,8 @@ class Spree::Review < ActiveRecord::Base
   def recalculate_product_rating
     self.product.recalculate_rating if product.present?
   end
+
+  def email
+    user.try!(:email)
+  end
 end

--- a/app/views/spree/admin/reviews/_form.html.erb
+++ b/app/views/spree/admin/reviews/_form.html.erb
@@ -4,6 +4,11 @@
   <%= f.text_field :name, :maxlength => "255", :size => "60" %>
 <% end %>
 
+<%= f.field_container :email do %>
+  <%= f.label :email %><br />
+  <%= mail_to @review.email %>
+<% end %>
+
 <%= f.field_container :title do %>
   <%= f.label :title %><br />
   <%= f.text_field :title, :maxlength => "255", :size => "60" %>

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'Review Admin' do
 
       expect(page).to have_text 'Editing'
       expect(page).to have_text review.title
+      expect(page).to have_css('a', text: review.email)
     end
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -165,4 +165,12 @@ describe Spree::Review do
       expect(review.feedback_stars).to eq 2
     end
   end
+
+  context "#email" do
+    it "returns email from user" do
+      user = build(:user, email: "john@smith.com")
+      review = build(:review, user: user)
+      expect(review.email).to eq("john@smith.com")
+    end
+  end
 end


### PR DESCRIPTION
This adds the user's email address to the admin review editing page.