### PR TITLE
Fix resetting preferences in specs

### DIFF
--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -75,6 +75,7 @@ describe Spree::Review do
 
       before do
         reset_spree_preferences
+        Spree::Reviews::Config.preference_store = Spree::Reviews::Config.default_preferences
       end
 
       it 'properly runs oldest_first queries' do
@@ -82,7 +83,7 @@ describe Spree::Review do
       end
 
       it 'uses oldest_first for preview' do
-        expect(Spree::Review.preview.to_a).to eq([review_1, review_3])
+        expect(Spree::Review.preview.to_a).to eq([review_1, review_3, review_2])
       end
     end
 

--- a/spec/models/reviews_configuration_spec.rb
+++ b/spec/models/reviews_configuration_spec.rb
@@ -5,6 +5,7 @@ describe Spree::ReviewsConfiguration do
 
   before do
     reset_spree_preferences
+    subject.preference_store = subject.default_preferences
   end
 
   it 'should have the include_unapproved_reviews preference' do
@@ -16,7 +17,7 @@ describe Spree::ReviewsConfiguration do
   it 'should have the preview_size preference' do
     expect(subject).to respond_to(:preferred_preview_size)
     expect(subject).to respond_to(:preferred_preview_size=)
-    expect(subject.preferred_preview_size).to eq(2)
+    expect(subject.preferred_preview_size).to eq(3)
   end
 
   it 'should have the show_email preference' do
@@ -37,7 +38,7 @@ describe Spree::ReviewsConfiguration do
     expect(subject.preferred_require_login).to be true
   end
 
-  it 'should have the track_locale preference', pending: 'this leaks from elsewhere, causes it to be true' do
+  it 'should have the track_locale preference' do
     expect(subject).to respond_to(:preferred_track_locale)
     expect(subject).to respond_to(:preferred_track_locale=)
     expect(subject.preferred_track_locale).to be false


### PR DESCRIPTION
Specs was failing randomly because preferences was not reset properly. `reset_spree_preferences` was just resetting `Spree::Config` preferences but not the `Spree::Reviews::Config` specific of this gem.

For example, a failing seed for specs was `37558`