### PR TITLE
Fix bundle install issue with solidus_auth_devise 2.0

### DIFF
--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus', ['>= 1.4', '< 3']
   s.add_dependency 'deface', '~> 1'
-  s.add_dependency 'solidus_auth_devise', '~> 1'
+  s.add_dependency 'solidus_auth_devise', ['>= 1.0', '< 3']
   s.add_dependency 'solidus_support', '~> 0.1.1'
 
   s.add_development_dependency 'ffaker'


### PR DESCRIPTION
After solidus_auth_devise 2.0 was released bundle cannot properly resolve dependencies and complete the install task. This PR fix this issue.