### PR TITLE
Fix Trevis CI badge to use master branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reviews
 
-[![Build Status](https://travis-ci.org/solidusio-contrib/solidus_reviews.svg)](https://travis-ci.org/solidusio-contrib/solidus_reviews)
+[![Build Status](https://travis-ci.org/solidusio-contrib/solidus_reviews.svg?branch=master)](https://travis-ci.org/solidusio-contrib/solidus_reviews)
 
 Straightforward review/rating functionality, updated for
 [Solidus](https://solidus.io). While the Gem name has changed, the module


### PR DESCRIPTION
We should show the master branch CI status and not the latest build status in the README.