### PR TITLE
Refactor spec helper to let specs pass

### DIFF
--- a/lib/solidus_reviews/factories/feedback_review_factory.rb
+++ b/lib/solidus_reviews/factories/feedback_review_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :feedback_review, :class => Spree::FeedbackReview do |f|
     user
     review

--- a/lib/solidus_reviews/factories/review_factory.rb
+++ b/lib/solidus_reviews/factories/review_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :review, :class => Spree::Review do |f|
     name   { generate(:random_email) }
     title  { generate(:random_string) }

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -20,14 +20,15 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus', ['>= 1.4', '< 3']
   s.add_dependency 'deface', '~> 1'
   s.add_dependency 'solidus_auth_devise', ['>= 1.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.1.1'
+  s.add_dependency 'solidus_support', '~> 0.1'
 
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'factory_girl'
+  s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'coffee-rails'

--- a/spec/features/reviews_spec.rb
+++ b/spec/features/reviews_spec.rb
@@ -18,7 +18,7 @@ feature 'Reviews', js: true do
     # Regression test for #103
     context "shows correct number of previews" do
       background do
-        FactoryGirl.create_list :review, 3, product: product_no_reviews, approved: true
+        FactoryBot.create_list :review, 3, product: product_no_reviews, approved: true
         Spree::Reviews::Config[:preview_size] = 2
       end
 
@@ -83,7 +83,7 @@ feature 'Reviews', js: true do
           fill_in 'review_review', with: 'Some big review text..'
           click_on 'Submit your review'
         end
-        
+
         expect(page.find('.flash.notice', text: Spree.t(:review_successfully_submitted))).to be_truthy
         expect(page).not_to have_text 'Some big review text..'
       end
@@ -93,7 +93,7 @@ feature 'Reviews', js: true do
   context 'visit product with review where show_identifier is false' do
     given!(:user) { create(:user) }
     given!(:review) { create(:review, :approved, :hide_identifier, review: 'review text', user: user) }
-    
+
     background do
       visit spree.product_path(review.product)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,25 +4,14 @@ SimpleCov.start 'rails'
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
-require 'rspec/rails'
-require 'ffaker'
-require 'database_cleaner'
-require 'capybara'
-require 'capybara/rspec'
-require 'capybara/rails'
-require 'capybara/poltergeist'
+
+# Requires factories and other useful helpers defined in spree_core.
+require "solidus_support/extension/feature_helper"
+require 'spree/testing_support/controller_requests'
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }
 
-require 'spree/testing_support/factories'
-require 'spree/testing_support/controller_requests'
-require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/preferences'
-require 'spree/testing_support/url_helpers'
-
 require 'solidus_reviews/factories'
-
-FactoryGirl.find_definitions
 
 # Bugfix for Solidus < 1.3 using ffaker 1.x
 if defined?(Faker)
@@ -31,25 +20,9 @@ end
 
 RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
-  config.include Spree::TestingSupport::Preferences
-  config.include FactoryGirl::Syntax::Methods
-  config.include Spree::TestingSupport::UrlHelpers
+
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
-
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.before do
-    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.start
-  end
-
-  config.after do
-    DatabaseCleaner.clean
-  end
 
   Capybara.javascript_driver = :poltergeist
 end


### PR DESCRIPTION
- use latest version of solidus_support which include facotry_bot
- refactor spec helper to use shared feature_spec helper from
  solidus_support
- change all references to FacotryGirl to FactoryBot