### PR TITLE
Improve specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,3 @@ env:
     - SOLIDUS_BRANCH=v2.1 DB=postgresql
     - SOLIDUS_BRANCH=master DB=mysql
     - SOLIDUS_BRANCH=master DB=postgresql
-before_install:
-  - rvm use @global
-  - gem uninstall bundler -x
-  - gem install bundler --version=1.13.7
-  - bundler --version

--- a/app/controllers/spree/reviews_controller.rb
+++ b/app/controllers/spree/reviews_controller.rb
@@ -1,7 +1,6 @@
 class Spree::ReviewsController < Spree::StoreController
   helper Spree::BaseHelper
   before_action :load_product, :only => [:index, :new, :create]
-  rescue_from ActiveRecord::RecordNotFound, :with => :render_404
 
   def index
     @approved_reviews = Spree::Review.approved.where(product: @product)

--- a/lib/solidus_reviews/factories/feedback_review_factory.rb
+++ b/lib/solidus_reviews/factories/feedback_review_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :feedback_review, :class => Spree::FeedbackReview do |f|
     user
     review
-    comment { generate(:random_description) }
     rating  { rand(1..5) }
   end
 end

--- a/lib/solidus_reviews/factories/review_factory.rb
+++ b/lib/solidus_reviews/factories/review_factory.rb
@@ -1,8 +1,7 @@
 FactoryBot.define do
   factory :review, :class => Spree::Review do |f|
-    name   { generate(:random_email) }
-    title  { generate(:random_string) }
-    review { generate(:random_description) }
+    sequence(:name) { |i| "User #{i}" }
+    review { 'This product is ok!' }
     rating { rand(1..5) }
     approved false
     show_identifier true

--- a/spec/controllers/feedback_reviews_controller_spec.rb
+++ b/spec/controllers/feedback_reviews_controller_spec.rb
@@ -22,7 +22,7 @@ describe Spree::FeedbackReviewsController do
   describe '#create' do
     it 'creates a new feedback review' do
       rating = 4
-      comment = FFaker::Lorem.paragraphs(3).join("\n")
+      comment = ['Thanks for your review!', 'Cheers'].join("\n")
       expect {
         post :create, params: { review_id: review.id,
                               feedback_review: { comment: comment,

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -19,8 +19,9 @@ describe Spree::ReviewsController, type: :controller do
   context '#index' do
     context 'for a product that does not exist' do
       it 'responds with a 404' do
-        get :index, params: { product_id: 'not_real'}
-        expect(response.status).to eq(404)
+        expect {
+          get :index, params: { product_id: 'not_real'}
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -39,8 +40,9 @@ describe Spree::ReviewsController, type: :controller do
   context '#new' do
     context 'for a product that does not exist' do
       it 'responds with a 404' do
-        get :new, params: { product_id: 'not_real' }
-        expect(response.status).to eq(404)
+        expect {
+          get :new, params: { product_id: 'not_real' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -64,8 +66,9 @@ describe Spree::ReviewsController, type: :controller do
 
     context 'for a product that does not exist' do
       it 'responds with a 404' do
-        post :create, params: { product_id: 'not_real' }
-        expect(response.status).to eq(404)
+        expect {
+          post :create, params: { product_id: 'not_real' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,11 +13,6 @@ Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }
 
 require 'solidus_reviews/factories'
 
-# Bugfix for Solidus < 1.3 using ffaker 1.x
-if defined?(Faker)
-  FFaker = Faker
-end
-
 RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
 


### PR DESCRIPTION
Fix specs following what's happening in solidus core:

- Use sequences instead of using solidus core ones. solidusio/solidus#2339
- Remove rescue from RecordNotFound with :render_404 solidusio/solidus#2329

Also remove other code that is no more needed.