### PR TITLE
Remove redundant rescue_from from api controller

### DIFF
--- a/lib/controllers/spree/api/reviews_controller.rb
+++ b/lib/controllers/spree/api/reviews_controller.rb
@@ -3,7 +3,6 @@ module Spree
     class ReviewsController < Spree::Api::BaseController
       respond_to :json
 
-      rescue_from ActiveRecord::RecordNotFound, with: :render_404
       before_action :load_review, only: [:show, :update, :destroy]
       before_action :load_product, :find_review_user
       before_action :sanitize_rating, only: [:create, :update]


### PR DESCRIPTION
This removes review's `rescue_from` because it is calling `render_404` which was removed and should be delegating that to the `Spree::Api::BaseController` anyways.

@tvdeyen I apologize that I missed this in the last PR #14.

`Spree::Api::BaseController` where that should be delegated to.
https://github.com/jhawthorn/solidus/blob/11658e4643d50e0daf49e55bee5334c309bdd82e/api/app/controllers/spree/api/base_controller.rb#L25