### PR TITLE
Resume the ability for guests to specify an email

### DIFF
--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -10,13 +10,13 @@ class Spree::Review < ActiveRecord::Base
   validates :review, presence: true
 
   validates :rating, numericality: { only_integer: true,
-                                     greater_than_or_equal_to: 1, 
+                                     greater_than_or_equal_to: 1,
                                      less_than_or_equal_to: 5,
                                      message: Spree.t('you_must_enter_value_for_rating') }
 
 
   default_scope { order("spree_reviews.created_at DESC") }
-  
+
   scope :localized, ->(lc) { where('spree_reviews.locale = ?', lc) }
   scope :most_recent_first, -> { order('spree_reviews.created_at DESC') }
   scope :oldest_first, -> { reorder('spree_reviews.created_at ASC') }
@@ -35,6 +35,6 @@ class Spree::Review < ActiveRecord::Base
   end
 
   def email
-    user.try!(:email)
+    user.try!(:email) || super
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -168,9 +168,14 @@ describe Spree::Review do
   end
 
   context "#email" do
-    it "returns email from user" do
+    it "returns email from user when there is a user" do
       user = build(:user, email: "john@smith.com")
       review = build(:review, user: user)
+      expect(review.email).to eq("john@smith.com")
+    end
+
+    it "returns email from review when there is no user" do
+      review = build(:review, email: "john@smith.com")
       expect(review.email).to eq("john@smith.com")
     end
   end


### PR DESCRIPTION
https://github.com/solidusio-contrib/solidus_reviews/pull/15 broke the ability for guests to specify their email manually, because `Review#email` will always delegate to `#user`.

Now `#email` will still delegate to `#user`, but fall back to the attribute on `Review` in case there is no user. 