### PR TITLE
Add missing TH tag

### DIFF
--- a/app/views/spree/admin/feedback_reviews/index.html.erb
+++ b/app/views/spree/admin/feedback_reviews/index.html.erb
@@ -21,7 +21,7 @@
 				<th><%= Spree.t('user') %></th>
 				<th><%= Spree.t('stars') %></th>
 				<th><%= Spree.t('date') %></th>
-				<th></th>
+				<th class="actions"></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -71,6 +71,7 @@
         <th><%= Spree.t('feedback') %></th>
         <th><%= Spree::Review.human_attribute_name(:user) %></th>
         <th><%= Spree::Review.human_attribute_name(:created_at) %></th>
+        <th class="actions"></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
The last `TH` tag (the one for actions column) was missing on the admin reviews
page. Since Solidus uses the css class `actions` for these tags, the same class
has been added here.