### PR TITLE
Avoid conflicts when same rating HTML is repeated on page

### DIFF
--- a/vendor/assets/javascripts/jquery.rating.js
+++ b/vendor/assets/javascripts/jquery.rating.js
@@ -52,7 +52,19 @@
 
 			// Load control parameters / find context / etc
 			var control, input = $(this);
-			var eid = (this.name || 'unnamed-rating').replace(/\[|\]/g, '_').replace(/^\_+|\_+$/g,'');
+
+			var getUniqueId = function(input) {
+				var parent = input.parent();
+				var uniqueId = parent.data('review-uniqueid');
+				if (!uniqueId && uniqueId !== 0) {
+					uniqueId = $.fn.rating.uniqueId;
+					parent.data('review-uniqueid', uniqueId);
+					$.fn.rating.uniqueId++;
+				}
+				return uniqueId;
+			};
+
+			var eid = (this.name || 'unnamed-rating').replace(/\[|\]/g, '_').replace(/^\_+|\_+$/g,'') + '-' + getUniqueId(input);
 			var context = $(this.form || document.body);
 
 			// FIX: http://code.google.com/p/jquery-star-rating-plugin/issues/detail?id=23
@@ -211,6 +223,7 @@
 		// Used to append a unique serial number to internal control ID
 		// each time the plugin is invoked so same name controls can co-exist
 		calls: 0,
+		uniqueId: 0,
 
 		focus: function(){
 			var control = this.data('rating'); if(!control) return this;

--- a/vendor/assets/javascripts/jquery.rating.js
+++ b/vendor/assets/javascripts/jquery.rating.js
@@ -10,15 +10,15 @@
 /*# AVOID COLLISIONS #*/
 ;if(window.jQuery) (function($){
 /*# AVOID COLLISIONS #*/
-	
+
 	// IE6 Background Image Fix
 	if ((!$.support.opacity && !$.support.style)) try { document.execCommand("BackgroundImageCache", false, true)} catch(e) { };
 	// Thanks to http://www.visualjquery.com/rating/rating_redux.html
-	
+
 	// plugin initialization
 	$.fn.rating = function(options){
 		if(this.length==0) return this; // quick fail
-		
+
 		// Handle API methods
 		if(typeof arguments[0]=='string'){
 			// Perform API methods on individual elements
@@ -33,44 +33,44 @@
 			// Quick exit...
 			return this;
 		};
-		
+
 		// Initialize options for this call
 		var options = $.extend(
 			{}/* new object */,
 			$.fn.rating.options/* default options */,
 			options || {} /* just-in-time options */
 		);
-		
+
 		// Allow multiple controls with the same name by making each call unique
 		$.fn.rating.calls++;
-		
+
 		// loop through each matched element
 		this
 		 .not('.star-rating-applied')
 			.addClass('star-rating-applied')
 		.each(function(){
-			
+
 			// Load control parameters / find context / etc
 			var control, input = $(this);
 			var eid = (this.name || 'unnamed-rating').replace(/\[|\]/g, '_').replace(/^\_+|\_+$/g,'');
 			var context = $(this.form || document.body);
-			
+
 			// FIX: http://code.google.com/p/jquery-star-rating-plugin/issues/detail?id=23
 			var raters = context.data('rating');
 			if(!raters || raters.call!=$.fn.rating.calls) raters = { count:0, call:$.fn.rating.calls };
 			var rater = raters[eid] || context.data('rating'+eid);
-			
+
 			// if rater is available, verify that the control still exists
 			if(rater) control = rater.data('rating');
-			
+
 			if(rater && control)//{// save a byte!
 				// add star to control if rater is available and the same control still exists
 				control.count++;
-				
+
 			//}// save a byte!
 			else{
 				// create new control if first star or control element was removed/replaced
-				
+
 				// Initialize options for this rater
 				control = $.extend(
 					{}/* new object */,
@@ -78,23 +78,23 @@
 					($.metadata? input.metadata(): ($.meta?input.data():null)) || {}, /* metadata options */
 					{ count:0, stars: [], inputs: [] }
 				);
-				
+
 				// increment number of rating controls
 				control.serial = raters.count++;
-				
+
 				// create rating element
 				rater = $('<span class="star-rating-control"/>');
 				input.before(rater);
-				
+
 				// Mark element for initialization (once all stars are ready)
 				rater.addClass('rating-to-be-drawn');
-				
+
 				// Accept readOnly setting from 'disabled' property
 				if(input.attr('disabled') || input.hasClass('disabled')) control.readOnly = true;
-				
+
 				// Accept required setting from class property (class='required')
 				if(input.hasClass('required')) control.required = true;
-				
+
 				// Create 'cancel' button
 				rater.append(
 					control.cancel = $('<div class="rating-cancel"><a title="' + control.cancel + '">' + control.cancelValue + '</a></div>')
@@ -113,20 +113,20 @@
 					})
 					.data('rating', control)
 				);
-				
+
 			}; // first element of group
-			
+
 			// insert rating star (thanks Jan Fanslau rev125 for blind support https://code.google.com/p/jquery-star-rating-plugin/issues/detail?id=125)
 			var star = $('<div role="text" aria-label="'+ this.title +'" class="star-rating rater-'+ control.serial +'"><a title="' + (this.title || this.value) + '">' + this.value + '</a></div>');
 			rater.append(star);
-			
+
 			// inherit attributes from input element
 			if(this.id) star.attr('id', this.id);
 			if(this.className) star.addClass(this.className);
-			
+
 			// Half-stars?
 			if(control.half) control.split = 2;
-			
+
 			// Prepare division control
 			if(typeof control.split=='number' && control.split>0){
 				var stw = ($.fn.width ? star.width() : 0) || control.starWidth;
@@ -138,7 +138,7 @@
 				// this is work-around to IE's stupid box model (position:relative doesn't work)
 				.find('a').css({ 'margin-left':'-'+ (spi*spw) +'px' })
 			};
-			
+
 			// readOnly?
 			if(control.readOnly)//{ //save a byte!
 				// Mark star as readOnly so user can customize display
@@ -161,49 +161,49 @@
 					})
 				;
 			//}; //save a byte!
-			
+
 			// set current selection
 			if(this.checked)	control.current = star;
-			
+
 			// set current select for links
 			if(this.nodeName=="A"){
     if($(this).hasClass('selected'))
      control.current = star;
    };
-			
+
 			// hide input element
 			input.hide();
-			
+
 			// backward compatibility, form element to plugin
 			input.on('change.rating',function(event){
 				if(event.selfTriggered) return false;
     $(this).rating('select');
    });
-			
+
 			// attach reference to star to input element and vice-versa
 			star.data('rating.input', input.data('rating.star', star));
-			
+
 			// store control information in form (or body when form not available)
 			control.stars[control.stars.length] = star[0];
 			control.inputs[control.inputs.length] = input[0];
 			control.rater = raters[eid] = rater;
 			control.context = context;
-			
+
 			input.data('rating', control);
 			rater.data('rating', control);
 			star.data('rating', control);
 			context.data('rating', raters);
 			context.data('rating'+eid, rater); // required for ajax forms
   }); // each element
-		
+
 		// Initialize ratings (first draw)
 		$('.rating-to-be-drawn').rating('draw').removeClass('rating-to-be-drawn');
-		
+
 		return this; // don't break the chain...
 	};
-	
+
 	/*--------------------------------------------------------*/
-	
+
 	/*
 		### Core functionality and API ###
 	*/
@@ -211,7 +211,7 @@
 		// Used to append a unique serial number to internal control ID
 		// each time the plugin is invoked so same name controls can co-exist
 		calls: 0,
-		
+
 		focus: function(){
 			var control = this.data('rating'); if(!control) return this;
 			if(!control.focus) return this; // quick fail if not required
@@ -220,7 +220,7 @@
    // focus handler, as requested by focusdigital.co.uk
 			if(control.focus) control.focus.apply(input[0], [input.val(), $('a', input.data('rating.star'))[0]]);
 		}, // $.fn.rating.focus
-		
+
 		blur: function(){
 			var control = this.data('rating'); if(!control) return this;
 			if(!control.blur) return this; // quick fail if not required
@@ -229,7 +229,7 @@
    // blur handler, as requested by focusdigital.co.uk
 			if(control.blur) control.blur.apply(input[0], [input.val(), $('a', input.data('rating.star'))[0]]);
 		}, // $.fn.rating.blur
-		
+
 		fill: function(){ // fill to the current mouse position.
 			var control = this.data('rating'); if(!control) return this;
 			// do not execute when control is in read-only mode
@@ -238,7 +238,7 @@
 			this.rating('drain');
 			this.prevAll().addBack().filter('.rater-'+ control.serial).addClass('star-rating-hover');
 		},// $.fn.rating.fill
-		
+
 		drain: function() { // drain all the stars.
 			var control = this.data('rating'); if(!control) return this;
 			// do not execute when control is in read-only mode
@@ -246,7 +246,7 @@
 			// Reset all stars
 			control.rater.children().filter('.rater-'+ control.serial).removeClass('star-rating-on').removeClass('star-rating-hover');
 		},// $.fn.rating.drain
-		
+
 		draw: function(){ // set value and stars to reflect current selection
 			var control = this.data('rating'); if(!control) return this;
 			// Clear all stars
@@ -260,11 +260,11 @@
 			// Add/remove read-only classes to remove hand pointer
 			this.siblings()[control.readOnly?'addClass':'removeClass']('star-rating-readonly');
 		},// $.fn.rating.draw
-		
-		
-		
-		
-		
+
+
+
+
+
 		select: function(value,wantCallBack){ // select a value
 			var control = this.data('rating'); if(!control) return this;
 			// do not execute when control is in read-only mode
@@ -310,11 +310,11 @@
 			// don't break the chain
 			return this;
   },// $.fn.rating.select
-		
-		
-		
-		
-		
+
+
+
+
+
 		readOnly: function(toggle, disable){ // make the control read-only (still submits value)
 			var control = this.data('rating'); if(!control) return this;
 			// setread-only status
@@ -327,19 +327,19 @@
 			// Update display
 			this.rating('draw');
 		},// $.fn.rating.readOnly
-		
+
 		disable: function(){ // make read-only and never submit value
 			this.rating('readOnly', true, true);
 		},// $.fn.rating.disable
-		
+
 		enable: function(){ // make read/write and submit value
 			this.rating('readOnly', false, false);
 		}// $.fn.rating.select
-		
+
  });
-	
+
 	/*--------------------------------------------------------*/
-	
+
 	/*
 		### Default Settings ###
 		eg.: You can override default control like this:
@@ -349,11 +349,11 @@
 			cancel: 'Cancel Rating',   // advisory title for the 'cancel' link
 			cancelValue: '',           // value to submit when user click the 'cancel' link
 			split: 0,                  // split the star into how many parts?
-			
+
 			// Width of star image in case the plugin can't work it out. This can happen if
 			// the jQuery.dimensions plugin is not available OR the image is hidden at installation
 			starWidth: 16//,
-			
+
 			//NB.: These don't need to be pre-defined (can be undefined/null) so let's save some code!
 			//half:     false,         // just a shortcut to control.split = 2
 			//required: false,         // disables the 'cancel' button so user can only select one of the specified values
@@ -361,16 +361,16 @@
 			//blur:     function(){},  // executed when stars are focused
 			//callback: function(){},  // executed when a star is clicked
  }; //} });
-	
+
 	/*--------------------------------------------------------*/
-	
-	
+
+
 	  // auto-initialize plugin
 				$(function(){
 				 $('input[type=radio].star').rating();
 				});
-	
-	
+
+
 /*# AVOID COLLISIONS #*/
 })(jQuery);
 /*# AVOID COLLISIONS #*/


### PR DESCRIPTION
When the same rating HTML is repeated more than once on the page (it may
happen as the product is listed both on the category page and among the
recently viewed items) then setting `eid` from `name` attribute will not
work correctly, as it will catch 2 ratings instead of only one.
    
Adding a unique counter to the element parent and adding it to `eid` 
prevents this kind of issue.

`jquery.rating.js` has been converted to Unix file format.