### PR TITLE
Remove Solidus v2.3 from Travis config (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ cache: bundler
 only: master
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql


### PR DESCRIPTION
As per @kennyadsl's request, this PR removes support for Solidus v2.3 as today (**01/31/19**) is the last day before reaching EOL; this patch should only be merged **past** the date previously mentioned.