### PR TITLE
Gem maintenance

### DIFF
--- a/lib/solidus_reviews/factories/review_factory.rb
+++ b/lib/solidus_reviews/factories/review_factory.rb
@@ -3,17 +3,17 @@ FactoryBot.define do
     sequence(:name) { |i| "User #{i}" }
     review { 'This product is ok!' }
     rating { rand(1..5) }
-    approved false
-    show_identifier true
+    approved { false }
+    show_identifier { true }
     user
     product
 
     trait :approved do
-      approved true
+      approved { true }
     end
 
     trait :hide_identifier do
-      show_identifier false
+      show_identifier { false }
     end
   end
 end

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'


### PR DESCRIPTION
This PR aims to fix some minor maintenance issues with this gem:

* Add dynamic attributes to review factory: static attributes (without a block) are no longer available in `factory_bot` 5
* Lock sqlite3 gem to version 1.3.6: see issue https://github.com/rails/rails/issues/35153
