### PR TITLE
Fix wrong locale id for require login in admin

### DIFF
--- a/app/views/spree/admin/review_settings/edit.html.erb
+++ b/app/views/spree/admin/review_settings/edit.html.erb
@@ -35,7 +35,7 @@
     <div class="field">
       <label>
         <%= check_box_tag('preferences[require_login]', "1", Spree::Reviews::Config[:require_login]) %>
-        <%= I18n.t("spree.spree_reviews.pero bunrequire_login") %>
+        <%= I18n.t("spree.spree_reviews.require_login") %>
       </label>
     </div>
     <div class="field">


### PR DESCRIPTION
This fixes the wrong locale id introduced in https://git.io/fj0Yj.

The original and correct locale id was replaced a while ago with a wrong one. That ended up forcing people to override the view or add the wrong id to their locale files (even to `en.yml` ones). This fixes the issue by reverting the change.