### PR TITLE
Rating only reviews

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -9,11 +9,11 @@ Spree::Product.class_eval do
   end
 
   def recalculate_rating
-    reviews_count = reviews.reload.approved.count
+    reviews_count = reviews.reload.default_approval_filter.count
 
     self.reviews_count = reviews_count
     if reviews_count > 0
-      self.avg_rating = reviews.approved.sum(:rating).to_f / reviews_count
+      self.avg_rating = '%.1f' % (reviews.default_approval_filter.sum(:rating).to_f / reviews_count)
     else
       self.avg_rating = 0
     end

--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -11,9 +11,6 @@ class Spree::Review < ActiveRecord::Base
   after_save :recalculate_product_rating, if: :approved?
   after_destroy :recalculate_product_rating
 
-  validates :name, presence: true
-  validates :review, presence: true
-
   validates :rating, numericality: { only_integer: true,
                                      greater_than_or_equal_to: 1,
                                      less_than_or_equal_to: 5,

--- a/app/models/spree/reviews_configuration.rb
+++ b/app/models/spree/reviews_configuration.rb
@@ -2,11 +2,14 @@
 
 class Spree::ReviewsConfiguration < Spree::Preferences::Configuration
   def self.boolean_preferences
-    %w(include_unapproved_reviews feedback_rating show_email require_login track_locale)
+    %w(display_unapproved_reviews include_unapproved_reviews feedback_rating show_email require_login track_locale)
   end
 
   # include non-approved reviews in (public) listings
   preference :include_unapproved_reviews, :boolean, default: false
+
+  # displays non-approved reviews in (public) listings
+  preference :display_unapproved_reviews, :boolean, default: false
 
   # control how many reviews are shown in summaries etc.
   preference :preview_size, :integer, default: 3
@@ -15,7 +18,7 @@ class Spree::ReviewsConfiguration < Spree::Preferences::Configuration
   preference :show_email, :boolean, default: false
 
   # show if a reviewer actually purchased the product
-  preference :show_verified_purchaser, :boolean, :default => false
+  preference :show_verified_purchaser, :boolean, default: false
 
   # show helpfullness rating form elements
   preference :feedback_rating, :boolean, default: false

--- a/app/views/spree/admin/review_settings/edit.html.erb
+++ b/app/views/spree/admin/review_settings/edit.html.erb
@@ -22,6 +22,12 @@
     </div>
     <div class="field">
       <label>
+        <%= check_box_tag('preferences[display_unapproved_reviews]', "1", Spree::Reviews::Config[:display_unapproved_reviews]) %>
+        <%= I18n.t("spree.spree_reviews.display_unapproved") %>
+      </label>
+    </div>
+    <div class="field">
+      <label>
         <%= check_box_tag('preferences[feedback_rating]', "1", Spree::Reviews::Config[:feedback_rating]) %>
         <%= I18n.t("spree.spree_reviews.feedback_rating") %>
       </label>

--- a/app/views/spree/reviews/_form.html.erb
+++ b/app/views/spree/reviews/_form.html.erb
@@ -7,7 +7,7 @@
   </p>
 
   <p class="review_name_field">
-    <%= f.label :name %> <span class="required">*</span><br />
+    <%= f.label :name %><br />
     <%= f.text_field :name, maxlength: "255", size: "50" %>
   </p>
 
@@ -17,7 +17,7 @@
   </p>
 
   <p class="review_review_field">
-    <%= f.label :review %> <span class="required">*</span><br />
+    <%= f.label :review %><br />
     <%= f.text_area :review, wrap: "virtual", rows: "10", cols: "50" %>
   </p>
 

--- a/app/views/spree/shared/_review.html.erb
+++ b/app/views/spree/shared/_review.html.erb
@@ -2,7 +2,7 @@
   <span class="reviews-rating" title="<%= txt_stars(review.rating) %>">
     <%= render "spree/reviews/stars", stars: review.rating %>
   </span>
-  <% if review.approved || Spree::Reviews::Config[:display_unapproved_reviews] %>
+  <% if review.approved? || Spree::Reviews::Config[:display_unapproved_reviews] %>
     <span itemprop="name"><%= review.title %></span>
     <br/>
     <span class="attribution"><%= I18n.t("spree.submitted_on") %> <strong><%= l review.created_at.to_date %></strong></span>

--- a/app/views/spree/shared/_review.html.erb
+++ b/app/views/spree/shared/_review.html.erb
@@ -2,35 +2,37 @@
   <span class="reviews-rating" title="<%= txt_stars(review.rating) %>">
     <%= render "spree/reviews/stars", stars: review.rating %>
   </span>
-  <span itemprop="name"><%= review.title %></span>
-  <br/>
-  <span class="attribution"><%= I18n.t("spree.submitted_on") %> <strong><%= l review.created_at.to_date %></strong></span>
-  <meta itemprop="datePublished" content="<%= review.created_at.to_date.to_s %>" />
+  <% if review.approved || Spree::Reviews::Config[:display_unapproved_reviews] %>
+    <span itemprop="name"><%= review.title %></span>
+    <br/>
+    <span class="attribution"><%= I18n.t("spree.submitted_on") %> <strong><%= l review.created_at.to_date %></strong></span>
+    <meta itemprop="datePublished" content="<%= review.created_at.to_date.to_s %>" />
 
-  <meta itemprop="reviewRating" content="<%= review.rating %>" />
-  <% if review.show_identifier %>
-    <% if Spree::Reviews::Config[:show_email] && review.user %>
-      <span itemprop="author"><%= review.user.email %></span>
+    <meta itemprop="reviewRating" content="<%= review.rating %>" />
+    <% if review.show_identifier %>
+      <% if Spree::Reviews::Config[:show_email] && review.user %>
+        <span itemprop="author"><%= review.user.email %></span>
+      <% else %>
+        <span itemprop="author"><%= review.name %></span>
+      <% end %>
     <% else %>
-      <span itemprop="author"><%= review.name %></span>
+        <span itemprop="author"><%= I18n.t("spree.anonymous") %></span>
     <% end %>
-  <% else %>
-      <span itemprop="author"><%= I18n.t("spree.anonymous") %></span>
-  <% end %>
-  <% if Spree::Reviews::Config[:show_verified_purchaser] && review.verified_purchaser? %>
-    <div><%= I18n.t("spree.verified_purchaser") %></div>
-  <% end %>
-  <div itemprop="reviewBody">
-    <%= simple_format(review.review) %>
-  </div>
-  <% review.images.each do |image| %>
-    <div itemprop="image">
-      <%= link_to image_tag(image.url(:product)), image.url(:original) %>
+    <% if Spree::Reviews::Config[:show_verified_purchaser] && review.verified_purchaser? %>
+      <div><%= I18n.t("spree.verified_purchaser") %></div>
+    <% end %>
+    <div itemprop="reviewBody">
+      <%= simple_format(review.review) %>
     </div>
-  <% end %>
-  <% if Spree::Reviews::Config[:feedback_rating] && (!Spree::Reviews::Config[:require_login] || spree_current_user) %>
-    <div class="feedback_review" id="feedback_review_<%= review.id %>">
-      <%= render "spree/feedback_reviews/form", review: review %>
-    </div>
+    <% review.images.each do |image| %>
+      <div itemprop="image">
+        <%= link_to image_tag(image.url(:product)), image.url(:original) %>
+      </div>
+    <% end %>
+    <% if Spree::Reviews::Config[:feedback_rating] && (!Spree::Reviews::Config[:require_login] || spree_current_user) %>
+      <div class="feedback_review" id="feedback_review_<%= review.id %>">
+        <%= render "spree/feedback_reviews/form", review: review %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -56,6 +56,7 @@ de-CH:
     review_successfully_submitted: "Ihre Rezension wurde erfolgreich übertragen. Vielen Dank!"
     spree_reviews:
       feedback_rating: Feedback für Rezensionen erlauben
+      display_unapproved: Zeigen Sie nicht genehmigte Bewertungen in Auflistungen an
       include_unapproved: Unveröffentlichte Rezensionen anzeigen
       manage_review_settings: Einstellungen für die Darstellung von Rezensionen
       preview_size: Größe der Vorschau

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -56,6 +56,7 @@ de:
     review_successfully_submitted: Ihre Rezension wurde erfolgreich übertragen. Vielen Dank!
     spree_reviews:
       feedback_rating: Feedback für Rezensionen erlauben
+      display_unapproved: Zeigen Sie nicht genehmigte Bewertungen in Auflistungen an
       include_unapproved: Unveröffentlichte Rezensionen anzeigen
       manage_review_settings: Einstellungen für die Darstellung von Rezensionen
       preview_size: Größe der Vorschau

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -55,6 +55,7 @@ en-GB:
     review_successfully_submitted: Review was successfully submitted
     spree_reviews:
       feedback_rating: Rate feedback
+      display_unapproved: Display unapproved reviews in listings
       include_unapproved: Include unapproved reviews in listings
       manage_review_settings: Control the display of reviews
       preview_size: Size of the review snippets

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
     review_successfully_submitted: Review was successfully submitted
     spree_reviews:
       feedback_rating: Rate feedback
+      display_unapproved: Display unapproved reviews in listings
       include_unapproved: Include unapproved reviews in listings
       manage_review_settings: Control the display of reviews
       preview_size: Size of the review snippets

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -55,6 +55,7 @@ es:
     review_successfully_submitted: "La valoración se ha enviado correctamente"
     spree_reviews:
       feedback_rating: "Puntuación en el feedback"
+      display_unapproved: "Mostrar comentarios no aprobados en los listados"
       include_unapproved: "Incluir en los listados las valoraciones sin aprobar"
       manage_review_settings: "Gestionar la publicación de valoraciones"
       preview_size: "Tamaño de la versión resumida de la valoración"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,6 +55,7 @@ fr:
     review_successfully_submitted: Votre commentaire a été envoyé avec succès
     spree_reviews:
       feedback_rating: Note de réaction
+      display_unapproved: Afficher les commentaires non approuvés dans les listes
       include_unapproved: Afficher les commentaires non modérés
       manage_review_settings: Contrôler l'affichage des commentaires
       preview_size: Taille des extraits de commentaires

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -54,6 +54,7 @@ it:
     review_successfully_submitted: La recensione è stata inviata con successo
     spree_reviews:
       feedback_rating: Aggiungi la possibilità di votare una recensione
+      display_unapproved: Visualizza recensioni non approvate negli elenchi
       include_unapproved: Mostra le recensioni non approvate
       manage_review_settings: Approva le recensioni prima della pubblicazione
       preview_size: Dimensione degli snippet per la recensione

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -57,6 +57,7 @@ pl:
     review_successfully_submitted: Opinia została dodana
     spree_reviews:
       feedback_rating: Oceń komentarz
+      display_unapproved: Wyświetlaj niezatwierdzone recenzje we wpisach
       include_unapproved: Załącz niezaakceptowane do listy
       manage_review_settings: Zarządzaj wyśiwetlaniem opinii
       preview_size: Liczba opinii na stronie produktu

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -55,6 +55,7 @@ pt-BR:
     review_successfully_submitted: 'Avaliação enviada com sucesso'
     spree_reviews:
       feedback_rating: 'Classifique um parecer'
+      display_unapproved: 'Exibir avaliações não aprovadas nas listagens'
       include_unapproved: 'Incluir avaliações não aprovadas na listagem'
       manage_review_settings: 'Controlar aparições das avaliações'
       preview_size: 'Tamanho da avaliação'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -56,6 +56,7 @@ pt:
     submission_guidelines: Diretrizes para enviar boas avaliações
     spree_reviews:
       feedback_rating: Pontuação de feedback
+      display_unapproved: Exibir avaliações não aprovadas nas listagens
       include_unapproved: Incluir avaliaçoes não-aprovadas nas lista
       manage_review_settings: Gerir a publicação de avaliações
       preview_size: Tamanho da versão resumida de avaliações

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -59,7 +59,8 @@ ro:
     review_successfully_submitted: Recenzia a fost trimisă cu succes
     spree_reviews:
       feedback_rating: Evaluează feedback
-      include_unapproved: Include recenzii neaprobate în listări
+      display_unapproved: Afișați recenzii neaprobate în înregistrări
+      include_unapproved: Includeți recenzii neaprobate în listări
       manage_review_settings: Controlează afișarea recenziilor
       preview_size: Mărimea fragmentului recenziei
       require_login: Solicită ca utilizatorul să fie autentificat

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -46,6 +46,7 @@ ru:
       review_settings: Настройки отзывов покупателей
       manage_review_settings: Управление отображением отзывов
       preview_size: Количество отзывов на странице товара
+      display_unapproved: Показать неутвержденные отзывы в списках
       include_unapproved: Показывать неодобренные отзывы на странице товара
       your_name: Ваше имя
       your_location: Город

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -55,6 +55,7 @@ sv:
     reviews: Recensioner
     spree_reviews:
       feedback_rating: Betygsåterkoppling
+      display_unapproved: "Visa ej godkända recensioner i listor"
       include_unapproved: "Inkludera inte godkända recensioner i listan"
       manage_review_settings: "Kontrollera visningen av recensionerna"
       preview_size: "Storlek på recensions snippets"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -55,6 +55,7 @@ tr:
     review_successfully_submitted: Yorumunuz başarıyla iletildi
     spree_reviews:
       feedback_rating: Geribildirimi değerlendir
+      display_unapproved: Listelerde onaylanmayan yorumları göster
       include_unapproved: Listede ki onaylanmamış değerlendirmeleri dahil et
       manage_review_settings: Yorum ekranını kontrol edin
       preview_size: Yorum büyüklüğü

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -59,6 +59,7 @@ uk:
     review_successfully_submitted: Відгук надіслано
     spree_reviews:
       feedback_rating: Оцінювати корисність
+      display_unapproved: Показувати в списках не схвалені відгуки
       include_unapproved: Показувати незатверджені відгуки
       manage_review_settings: Керувати відображенням відгуків
       preview_size: Розмір скороченої версії

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -53,6 +53,7 @@ zh-CN:
     review_successfully_submitted: 已成功递交评论。
     spree_reviews:
       feedback_rating: 评级回馈
+      display_unapproved: 在列表中显示未经批准的评论
       include_unapproved: 包括未核准评论在列表中
       manage_review_settings: 控制评论的显示
       preview_size: 评论片段的大小

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -53,6 +53,7 @@ zh-TW:
     review_successfully_submitted: 已成功遞交評論。
     spree_reviews:
       feedback_rating: 評級回饋
+      display_unapproved: 在列表中顯示未經批准的評論
       include_unapproved: 包括未核準評論在列表中
       manage_review_settings: 控制評論的顯示
       preview_size: 評論片段的大小

--- a/lib/solidus_reviews/factories/review_factory.rb
+++ b/lib/solidus_reviews/factories/review_factory.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :review, class: Spree::Review do |_f|
     sequence(:name) { |i| "User #{i}" }
+    title { FFaker::Book.title }
     review { 'This product is ok!' }
     rating { rand(1..5) }
     approved { false }

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -85,6 +85,17 @@ describe Spree::ReviewsController, type: :controller do
       }.to change(Spree::Review, :count).by(1)
     end
 
+    it 'creates a rating only review' do
+      review_params = {
+        product_id: product.slug,
+        review: { rating: 3 }
+      }
+
+      expect {
+        post :create, params: review_params
+      }.to change(Spree::Review, :count).by(1)
+    end
+
     it 'sets the ip-address of the remote' do
       @request.env['REMOTE_ADDR'] = '127.0.0.1'
       post :create, params: review_params

--- a/spec/features/reviews_spec.rb
+++ b/spec/features/reviews_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 feature 'Reviews', js: true do
   given!(:someone) { create(:user, email: 'ryan@spree.com') }
   given!(:review) { create(:review, :approved, user: someone) }
+  given!(:unapproved_review) { create(:review, product: review.product) }
 
   background do
     Spree::Reviews::Config.include_unapproved_reviews = false
@@ -65,6 +66,19 @@ feature 'Reviews', js: true do
 
       scenario 'can see review title' do
         expect(page).to have_text review.title
+      end
+
+      context 'with unapproved content allowed' do
+        background do
+          Spree::Reviews::Config[:include_unapproved_reviews] = true
+          Spree::Reviews::Config[:display_unapproved_reviews] = true
+          visit spree.product_path(review.product)
+        end
+
+        scenario 'can see unapproved content when allowed' do
+          expect(unapproved_review.approved?).to eq(false)
+          expect(page).to have_text unapproved_review.title
+        end
       end
 
       scenario 'can see create new review button' do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -35,18 +35,39 @@ describe Spree::Product do
       let!(:approved_review_2) { create(:review, product: product, approved: true, rating: 5) }
       let!(:unapproved_review_1) { create(:review, product: product, approved: false, rating: 4) }
 
-      it "updates the product average rating and ignores unapproved reviews" do
-        product.avg_rating = 0
-        product.reviews_count = 0
-        product.save!
+      context "including unapproved reviews" do
+        before(:all) do
+          Spree::Reviews::Config[:include_unapproved_reviews] = true
+        end
+        after(:all) do
+          Spree::Reviews::Config[:include_unapproved_reviews] = false
+        end
 
-        product.recalculate_rating
-        expect(product.avg_rating).to eq(4.5)
-        expect(product.reviews_count).to eq(2)
+        it "updates the product average rating and ignores unapproved reviews" do
+          product.avg_rating = 0
+          product.reviews_count = 0
+          product.save!
+
+          product.recalculate_rating
+          expect(product.avg_rating).to eq(4.3)
+          expect(product.reviews_count).to eq(3)
+        end
+      end
+
+      context "only approved reviews" do
+        it "updates the product average rating and ignores unapproved reviews" do
+          product.avg_rating = 0
+          product.reviews_count = 0
+          product.save!
+
+          product.recalculate_rating
+          expect(product.avg_rating).to eq(4.5)
+          expect(product.reviews_count).to eq(2)
+        end
       end
     end
 
-    context 'when no approved reviews' do
+    context "without unapproved reviews" do
       let!(:unapproved_review_1) { create(:review, product: product, approved: false, rating: 4) }
 
       it "updates the product average rating and ignores unapproved reviews" do

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -12,8 +12,8 @@ describe Spree::Review do
       expect(build(:review, user: nil)).to be_valid
     end
 
-    it 'does not validate with a nil review' do
-      expect(build(:review, review: nil)).to_not be_valid
+    it 'validates with a nil review' do
+      expect(build(:review, review: nil)).to be_valid
     end
 
     context 'rating' do
@@ -47,8 +47,8 @@ describe Spree::Review do
     end
 
     context 'review body' do
-      it 'should not be valid without a body' do
-        expect(build(:review, review: nil)).to_not be_valid
+      it 'should be valid without a body' do
+        expect(build(:review, review: nil)).to be_valid
       end
     end
   end


### PR DESCRIPTION
Support for rating only reviews. This will allow users to leave a star-only
review and have it be part of the calculation for average rating. If content
is entered, the stars can still be evaluated in the score while pending an
approval for the content.