### PR TITLE
General Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See corresponding [contributing guidelines][1].
 
 ---
 
-Copyright (c) 2009-2014 [Solidus][2] and [contributors][3], released under the [New BSD License][4]
+Copyright (c) 2009-2019 [Solidus][2] and [contributors][3], released under the [New BSD License][4]
 
 [1]: ./CONTRIBUTING.md
 [2]: https://github.com/solidusio

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.required_ruby_version = '>= 1.9.3'
 
-  s.homepage     = 'https://github.com/solidusio-contrib/solidus-reviews/'
+  s.homepage     = 'https://github.com/solidusio-contrib/solidus_reviews/'
   s.license      = 'BSD-3'
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
Fixes typo in homepage URL and year on README in
preparation for a 1.1 release.