### PR TITLE
Remove solidus_auth_devise as dependency

### DIFF
--- a/lib/solidus_reviews.rb
+++ b/lib/solidus_reviews.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'solidus'
+require 'solidus_support'
 require 'sass/rails'
 require 'deface'
-require 'solidus_auth_devise'
 require 'spree_reviews/engine'
 require 'coffee_script'

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface', '~> 1'
   s.add_dependency 'solidus', ['>= 1.4', '< 3']
-  s.add_dependency 'solidus_auth_devise', ['>= 1.0', '< 3']
   s.add_dependency 'solidus_support', '~> 0.1'
 
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
There's no need to keep `solidus_auth_devise` as an extension dependency.

There are several points where having a user is involved but it's correctly handled with `Spree.user_class`.

This PR, after a new release of this extension, fixes https://github.com/solidusio/solidus_auth_devise/issues/169