### PR TITLE
Fix error when trying to call image.url

### DIFF
--- a/app/views/spree/admin/reviews/_form.html.erb
+++ b/app/views/spree/admin/reviews/_form.html.erb
@@ -25,7 +25,7 @@
     <% @review.images.each do |image| %>
       <tr>
         <td>
-          <%= image_tag image.url(:original) %>
+          <%= image_tag image.attachment(:original) %>
         </td>
         <td>
           <%= link_to_delete image, url: admin_review_image_url(@review, image, product_id: @review.product), no_text: true  %>

--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -102,7 +102,7 @@
           </td>
           <td class="align-center">
             <% review.images.each do |image| %>
-              <%= link_to image_tag(image.url(:product)), image.url(:original) %>
+              <%= link_to image_tag(image.attachment(:product)), image.attachment(:original) %>
             <% end %>
           </td>
           <td class="actions">

--- a/app/views/spree/shared/_review.html.erb
+++ b/app/views/spree/shared/_review.html.erb
@@ -26,7 +26,7 @@
     </div>
     <% review.images.each do |image| %>
       <div itemprop="image">
-        <%= link_to image_tag(image.url(:product)), image.url(:original) %>
+        <%= link_to image_tag(image.attachment(:product)), image.attachment(:original) %>
       </div>
     <% end %>
     <% if Spree::Reviews::Config[:feedback_rating] && (!Spree::Reviews::Config[:require_login] || spree_current_user) %>


### PR DESCRIPTION
on the views it's belived that image is a `Paperclip::Attachment`
instance which can respond_to `#url` but in reality `image` is a
`Spree::Image` instance which can not respond_to `url`. So we need to use
the `#attachment` method instead to get the actual paperclip attachment
instance and pass it the size to get the actual url.

Fixes #59