### PR TITLE
Fix pragma comment can't modifed frozen string

### DIFF
--- a/app/overrides/add_reviews_tab_to_admin.rb
+++ b/app/overrides/add_reviews_tab_to_admin.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Spree::Backend::Config.configure do |config|
   config.menu_items.detect { |menu_item|
     menu_item.label == :products

--- a/app/overrides/add_reviews_to_admin_configuration_sidebar.rb
+++ b/app/overrides/add_reviews_to_admin_configuration_sidebar.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Spree::Backend::Config.configure do |config|
   config.menu_items.detect { |menu_item|
     menu_item.label == :settings


### PR DESCRIPTION
For some reason deface it's triggering a frozen string error. The only
way I could think to fix the issue was disableing the frozen string magic
comment.

Fixes #58