### PR TITLE
Switch to sassc/rails

### DIFF
--- a/lib/solidus_reviews.rb
+++ b/lib/solidus_reviews.rb
@@ -2,7 +2,7 @@
 
 require 'solidus'
 require 'solidus_support'
-require 'sass/rails'
+require 'sassc/rails'
 require 'deface'
 require 'spree_reviews/engine'
 require 'coffee_script'

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-rails', '~> 4.0.0.beta2'
   s.add_development_dependency 'rubocop', '~> 0.53.0'
-  s.add_development_dependency 'sass-rails'
+  s.add_development_dependency 'sassc-rails'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Ruby Sass EOL was 26 Mar 2019:
https://github.com/rails/sass-rails/issues/420

This PR updates the extension to use sassc instead. Closes #48 and #49.