### PR TITLE
Add touch to feedback review model

### DIFF
--- a/app/models/spree/feedback_review.rb
+++ b/app/models/spree/feedback_review.rb
@@ -3,7 +3,7 @@
 class Spree::FeedbackReview < ApplicationRecord
   belongs_to :user, class_name: Spree.user_class.to_s, optional: true
 
-  belongs_to :review
+  belongs_to :review, touch: true
   validates :review, presence: true
 
   validates :rating, numericality: { only_integer: true,

--- a/spec/controllers/spree/api/feedback_reviews_controller_spec.rb
+++ b/spec/controllers/spree/api/feedback_reviews_controller_spec.rb
@@ -47,6 +47,12 @@ describe Spree::Api::FeedbackReviewsController, type: :controller do
         expect(subject["rating"]).to eq(5)
         expect(subject["comment"]).to eq("I agree with what you said")
       end
+
+      it 'updates the review' do
+        expect(review).to receive(:touch)
+        feedback = create(:feedback_review, review: review)
+        feedback.save!
+      end
     end
   end
 


### PR DESCRIPTION
Basically updates the Review whenever a feedback_review is updated. This will prevent stale data being returned from caching.