### PR TITLE
Add option to auto approve star only reviews

### DIFF
--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -7,8 +7,8 @@ class Spree::Review < ApplicationRecord
   has_many   :images, -> { order(:position) }, as: :viewable,
                                                dependent: :destroy, class_name: "Spree::Image"
 
-  before_create :verify_purchaser
-  after_save :approve_review
+  before_save :verify_purchaser
+  before_save :approve_review, unless: :approved?
   after_save :recalculate_product_rating, if: :approved?
   after_destroy :recalculate_product_rating
 
@@ -59,7 +59,7 @@ class Spree::Review < ApplicationRecord
   end
 
   def approve_review
-    # Should auto approve review?
+    # Checks if we should auto approve the review.
     if Spree::Reviews::Config[:approve_star_only]
       self.approved = true if star_only?
     elsif Spree::Reviews::Config[:approve_star_only_for_verified_purchaser]

--- a/app/models/spree/reviews_configuration.rb
+++ b/app/models/spree/reviews_configuration.rb
@@ -31,4 +31,10 @@ class Spree::ReviewsConfiguration < Spree::Preferences::Configuration
 
   # render checkbox for a user to approve to show their identifier (name or email) on their review
   preference :render_show_identifier_checkbox, :boolean, default: false
+
+  # Approves star only reviews automatically (Reviews without a Title/Review)
+  preference :approve_star_only, :boolean, default: false
+
+  # Approves star only reviews for verified purchasers only.
+  preference :approve_star_only_for_verified_purchaser, :boolean, default: false
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -219,4 +219,31 @@ describe Spree::Review do
       expect(review.verified_purchaser).to eq(false)
     end
   end
+
+  describe "#approve_review" do
+    let(:order) { create(:completed_order_with_totals) }
+    let(:product) { order.products.first }
+    let(:user) { order.user }
+    let(:review) { build(:review, title: '', review: '', user: user, product: product) }
+
+    it "auto approves star only review" do
+      stub_spree_preferences(Spree::Reviews::Config, approve_star_only: true)
+
+      expect(review.approved).to eq(false)
+      review.approve_review
+      expect(review.approved).to eq(true)
+    end
+
+    it "auto approves star only review for verified purchaser" do
+      stub_spree_preferences(Spree::Reviews::Config, approve_star_only_for_verified_purchaser: true)
+
+      expect(review.verified_purchaser).to eq(false)
+      expect(review.approved).to eq(false)
+      review.verify_purchaser
+      expect(review.verified_purchaser).to eq(true)
+      expect(review.approved).to eq(false)
+      review.approve_review
+      expect(review.approved).to eq(true)
+    end
+  end
 end

--- a/spec/models/reviews_configuration_spec.rb
+++ b/spec/models/reviews_configuration_spec.rb
@@ -50,4 +50,16 @@ describe Spree::ReviewsConfiguration do
     expect(subject).to respond_to(:preferred_track_locale=)
     expect(subject.preferred_track_locale).to be false
   end
+
+  it 'has the approve_star_only preference' do
+    expect(subject).to respond_to(:preferred_approve_star_only)
+    expect(subject).to respond_to(:preferred_approve_star_only=)
+    expect(subject.preferred_approve_star_only).to be false
+  end
+
+  it 'has the approve_star_only_for_verified_purchaser preference' do
+    expect(subject).to respond_to(:preferred_approve_star_only_for_verified_purchaser)
+    expect(subject).to respond_to(:preferred_approve_star_only_for_verified_purchaser=)
+    expect(subject.preferred_approve_star_only_for_verified_purchaser).to be false
+  end
 end


### PR DESCRIPTION
This PR adds two new config options.

`approve_star_only`

When set to `true` all created/updated reviews with just a star rating, no title/review, will be automatically approved.

`approve_star_only_for_verified_purchaser`

Similar to `approve_star_only`. When this option is set to `true` will auto-approve star only reviews only if the review user is a verified purchaser.