### PR TITLE
Adds controls for image uploads

### DIFF
--- a/app/models/spree/reviews_configuration.rb
+++ b/app/models/spree/reviews_configuration.rb
@@ -2,7 +2,7 @@
 
 class Spree::ReviewsConfiguration < Spree::Preferences::Configuration
   def self.boolean_preferences
-    %w(display_unapproved_reviews include_unapproved_reviews feedback_rating show_email require_login track_locale)
+    %w(display_unapproved_reviews include_unapproved_reviews feedback_rating show_email require_login track_locale allow_image_upload)
   end
 
   # include non-approved reviews in (public) listings
@@ -37,4 +37,7 @@ class Spree::ReviewsConfiguration < Spree::Preferences::Configuration
 
   # Approves star only reviews for verified purchasers only.
   preference :approve_star_only_for_verified_purchaser, :boolean, default: false
+
+  # allow customer to update image with the review
+  preference :allow_image_upload, :boolean, default: true
 end

--- a/app/views/spree/admin/review_settings/edit.html.erb
+++ b/app/views/spree/admin/review_settings/edit.html.erb
@@ -57,6 +57,13 @@
       </label>
     </div>
     <div class="field">
+      <label>
+        <%= check_box_tag('preferences[allow_image_upload]', "1", Spree::Reviews::Config[:allow_image_upload]) %>
+        <%= I18n.t("spree.spree_reviews.allow_image_upload") %>
+      </label>
+    </div>
+
+    <div class="field">
       <label><%= I18n.t("spree.spree_reviews.preview_size") %></label><br>
       <%= text_field_tag('preferences[preview_size]', Spree::Reviews::Config[:preview_size], size: 3) %>
     </div>

--- a/app/views/spree/reviews/_form.html.erb
+++ b/app/views/spree/reviews/_form.html.erb
@@ -21,10 +21,12 @@
     <%= f.text_area :review, wrap: "virtual", rows: "10", cols: "50" %>
   </p>
 
-  <p class="review_images_field">
-    <%= f.label :images %><br>
-    <%= f.file_field :images, :accept => "image/*", multiple: true %>
-  </p>
+  <% if Spree::Reviews::Config[:allow_image_upload] %>
+    <p class="review_images_field">
+      <%= f.label :images %><br>
+      <%= f.file_field :images, :accept => "image/*", multiple: true %>
+    </p>
+  <% end %>
 
   <% if Spree::Reviews::Config[:render_show_identifier_checkbox] %>
     <p class="review_show_identifier_field">

--- a/app/views/spree/shared/_review.html.erb
+++ b/app/views/spree/shared/_review.html.erb
@@ -24,10 +24,12 @@
     <div itemprop="reviewBody">
       <%= simple_format(review.review) %>
     </div>
-    <% review.images.each do |image| %>
-      <div itemprop="image">
-        <%= link_to image_tag(image.url(:product)), image.url(:original) %>
-      </div>
+    <% if Spree::Reviews::Config[:allow_image_upload] %>
+      <% review.images.each do |image| %>
+        <div itemprop="image">
+          <%= link_to image_tag(image.url(:product)), image.url(:original) %>
+        </div>
+      <% end %>
     <% end %>
     <% if Spree::Reviews::Config[:feedback_rating] && (!Spree::Reviews::Config[:require_login] || spree_current_user) %>
       <div class="feedback_review" id="feedback_review_<%= review.id %>">

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -64,6 +64,7 @@ en-GB:
       show_email: Show email addresses
       show_verified_purchaser: Show verified purchaser
       track_locale: Track user's locale
+      allow_image_upload: Allow images to be attached to reviews
     star:
       one: "1"
       other: "%{count}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
       show_email: Show email addresses
       show_verified_purchaser: Show verified purchaser
       track_locale: Track user's locale
+      allow_image_upload: Allow images to be attached to reviews
     star:
       one: "1"
       other: "%{count}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -64,6 +64,7 @@ es:
       show_email: "Mostrar las direcciones de correo"
       show_verified_purchaser: Mostrar comprador verificado
       track_locale: "Rastrear el locale del usuario"
+      allow_image_upload: "Permitir adjuntar imagenes con el comentario"
     star:
       one: "1"
       other: "%{count}"


### PR DESCRIPTION
Hello

This feature allows the admin to switch on/off the image upload with reviews. In this way some store could restrict reviews to be text only and no images are upload to the back-end. By default is `true` as it is the default value, but it could be set to false in the admin.

Regards