### PR TITLE
Adds product already reviewed by customer

### DIFF
--- a/app/helpers/spree/reviews_helper.rb
+++ b/app/helpers/spree/reviews_helper.rb
@@ -24,4 +24,18 @@ module Spree::ReviewsHelper
                      spree_orders: { user_id: review.user_id }
                    ).present?
   end
+
+  def product_already_reviewed?(product, user)
+    return false if user.nil? || product.nil?
+
+    purchased_product_count_by_user = Spree::LineItem.joins(:order, :variant)
+      .where.not(spree_orders: { completed_at: nil })
+      .where(spree_variants: { product_id: product.id }, spree_orders: { user_id: user.id })
+      .count
+
+    review_counter_by_user = product.reviews.where({ user_id: user.id }).count
+
+    purchased_product_count_by_user > review_counter_by_user
+  end
+
 end


### PR DESCRIPTION
Hello

I created this helper method in order to check if a customer has already reviewed a product, taking into account that the customer can purchased multiple times the product. So the method checks how many times the product has been purchased by the customer and how many reviews the customer has posted for that product. In that way the customer could review only once per purchased. 

Let me know what you think

Regards