### PR TITLE
Adds PermissionSets classes and checks for Reviews

### DIFF
--- a/app/models/spree/permission_sets/review_display.rb
+++ b/app/models/spree/permission_sets/review_display.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PermissionSets
+    class ReviewDisplay < PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::Review
+      end
+    end
+  end
+end

--- a/app/models/spree/permission_sets/review_management.rb
+++ b/app/models/spree/permission_sets/review_management.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PermissionSets
+    class ReviewManagement < PermissionSets::Base
+      def activate!
+        can :manage, Spree::Review
+      end
+    end
+  end
+end

--- a/app/overrides/add_reviews_tab_to_admin.rb
+++ b/app/overrides/add_reviews_tab_to_admin.rb
@@ -6,7 +6,15 @@ Spree::Backend::Config.configure do |config|
   }.sections << :reviews
 end
 
-Deface::Override.new(virtual_path: "spree/admin/shared/_product_sub_menu",
-                     name: "reviews_admin_tab",
-                     insert_bottom: "[data-hook='admin_product_sub_tabs']",
-                     text: "<%= tab(:reviews, label: 'review_management') %>")
+Deface::Override.new(
+  virtual_path: "spree/admin/shared/_product_sub_menu",
+  name: "reviews_admin_tab",
+  insert_bottom: "[data-hook='admin_product_sub_tabs']",
+  disabled: false
+) do
+  <<-HTML
+    <% if can? :admin, Spree::Review %>
+      <%= tab(:reviews, label: 'review_management') %>
+    <% end %>
+  HTML
+end

--- a/app/overrides/add_reviews_to_admin_configuration_sidebar.rb
+++ b/app/overrides/add_reviews_to_admin_configuration_sidebar.rb
@@ -6,8 +6,15 @@ Spree::Backend::Config.configure do |config|
   }.sections << :review_settings
 end
 
-Deface::Override.new(virtual_path: "spree/admin/shared/_settings_sub_menu",
-                     name: "converted_admin_configurations_menu",
-                     insert_bottom: "[data-hook='admin_settings_sub_tabs']",
-                     text: "<%= tab :reviews, url: spree.edit_admin_review_settings_path, match_path: /review_settings/ %>",
-                     disabled: false)
+Deface::Override.new(
+  virtual_path: "spree/admin/shared/_settings_sub_menu",
+  name: "converted_admin_configurations_menu",
+  insert_bottom: "[data-hook='admin_settings_sub_tabs']",
+  disabled: false
+) do
+  <<-HTML
+    <% if can? :admin, Spree::ReviewsConfiguration %>
+      <%= tab :reviews, url: spree.edit_admin_review_settings_path, match_path: /review_settings/ %>
+    <% end %>
+  HTML
+end

--- a/app/views/spree/admin/reviews/edit.html.erb
+++ b/app/views/spree/admin/reviews/edit.html.erb
@@ -21,6 +21,8 @@
 	<div class="clear"></div>
 
 	<fieldset class="no-border-top">
-		<%= render 'spree/admin/shared/edit_resource_links' %>
+		<% if can? :manage, Spree::Review %>
+			<%= render 'spree/admin/shared/edit_resource_links' %>
+		<% end %>
 	</fieldset>
 <% end %>

--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -5,7 +5,9 @@
 <% end %>
 
 <% content_for :table_filter_title do %>
-  <%= I18n.t("spree.search") %>
+  <% if can? :display, Spree::Review %>
+    <%= I18n.t("spree.search") %>
+  <% end %>
 <% end %>
 
 <% content_for :table_filter do %>
@@ -106,9 +108,11 @@
             <% end %>
           </td>
           <td class="actions">
-            <%= link_to_with_icon 'ok', I18n.t("spree.approve"), approve_admin_review_url(review), no_text: true, class: 'approve' unless review.approved %>
-            <%= link_to_edit review, no_text: true, class: 'edit' %>
-            <%= link_to_delete review, no_text: true %>
+            <% if can? :manage, Spree::Review %>
+              <%= link_to_with_icon 'ok', I18n.t("spree.approve"), approve_admin_review_url(review), no_text: true, class: 'approve' unless review.approved %>
+              <%= link_to_edit review, no_text: true, class: 'edit' %>
+              <%= link_to_delete review, no_text: true %>
+            <% end %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
Hello

I created a couple of permission sets for this extension in order to have more control of access on reviews for admin customers. In that way we could have admin users to change the overall configuration and other admin users with access only for reviews themselves. It works along the `Spree::PermissinSets` classes and it could be integrated with the extension `https://github.com/boomerdigital/solidus_user_roles`.

Let me know what you think

Happy to fix if you guys spot something wrong.