### PR TITLE
Implement Google Product Reviews feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,31 @@ That's all!
 
 ## Usage
 
+### Reviews
+
 The `Spree::ReviewsController` controller provides all the CRUD functionality for product reviews.
+
+You can approve, edit and delete reviews from the backend.
+
+### Feedback reviews
 
 The `Spree::FeedbackReviewsController` allows user to express their feedback on a specific review.
 You can think of these as meta-reviews (e.g. the classic "Was this useful?" modal).
 
-You can approve, edit and delete reviews and feedback reviews from the backend.
+### Reviews feed
+
+The `Spree::ReviewsFeedController` generates an XML feed compliant with the
+[Google Product Review Feeds](https://developers.google.com/product-review-feeds) schema, which can
+be imported into Google Merchant Center.
+
+By default, this functionality is disabled. The reason is that the gem ships with a very naive
+implementation that generates the XML feed on demand when the controller is called. This will cause
+performance issues and ultimately lead to timeouts in stores with a large number of reviews.
+
+If you have a lot of reviews, a better strategy is to generate the feed periodically and upload it
+to S3, then have Google pull it from there.
+
+You can enable the default implementation through the `enable_reviews_feed` option.
 
 ## Factories
 

--- a/app/controllers/spree/reviews_feeds_controller.rb
+++ b/app/controllers/spree/reviews_feeds_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree
+  class ReviewsFeedsController < Spree::StoreController
+    def show
+      @approved_reviews = Spree::Review.approved.order(created_at: :desc)
+
+      respond_to do |format|
+        format.xml
+      end
+    end
+  end
+end

--- a/app/models/spree/reviews_configuration.rb
+++ b/app/models/spree/reviews_configuration.rb
@@ -37,4 +37,8 @@ class Spree::ReviewsConfiguration < Spree::Preferences::Configuration
 
   # Approves star only reviews for verified purchasers only.
   preference :approve_star_only_for_verified_purchaser, :boolean, default: false
+
+  # Enables the Google Shopping product reviews feed.
+  # This will likely cause performance issues if you have a large number of reviews.
+  preference :enable_reviews_feed, :boolean, default: false
 end

--- a/app/views/spree/reviews_feeds/show.xml.builder
+++ b/app/views/spree/reviews_feeds/show.xml.builder
@@ -1,0 +1,50 @@
+xml.instruct! :xml, version: "1.0", encoding: 'UTF-8'
+
+xml.feed(
+  'xmlns:vc' => "http://www.w3.org/2007/XMLSchema-versioning",
+  'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+  'xsi:noNamespaceSchemaLocation' => "http://www.google.com/shopping/reviews/schema/product/2.2/product_reviews.xsd",
+) do
+  xml.version '2.2'
+
+  xml.publisher do
+    xml.name current_store.name
+    xml.favicon "#{current_store.url}/favicon.ico"
+  end
+
+  xml.reviews do
+    @approved_reviews.each do |review|
+      xml.review do
+        xml.review_id review.id
+        xml.reviewer do
+          xml.name(review.name, is_anonymous: !review.user)
+          if review.user
+            xml.reviewer_id review.user.id
+          end
+        end
+        xml.review_timestamp review.created_at.xmlschema
+        if review.title.present?
+          xml.title review.title
+        end
+        xml.content review.review
+        xml.review_url spree.product_url(review.product), type: 'group'
+        xml.ratings do
+          xml.overall review.rating, min: 1, max: 5
+        end
+        xml.products do
+          xml.product do
+            xml.product_ids do
+              xml.skus do
+                review.product.variants_including_master.each do |variant|
+                  xml.sku variant.sku
+                end
+              end
+            end
+            xml.product_name review.product.name
+            xml.product_url spree.product_url(review.product)
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,12 @@ Spree::Core::Engine.routes.draw do
     resources :reviews, only: [:index, :new, :create, :edit, :update] do
     end
   end
+
   post '/reviews/:review_id/feedback(.:format)' => 'feedback_reviews#create', as: :feedback_reviews
+
+  if Spree::Reviews::Config[:enable_reviews_feed]
+    resource :reviews_feed, only: :show
+  end
 
   if SolidusSupport.api_available?
     namespace :api, defaults: { format: 'json' } do

--- a/lib/solidus_reviews/engine.rb
+++ b/lib/solidus_reviews/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusReviews
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 

--- a/lib/solidus_reviews/factories/review_factory.rb
+++ b/lib/solidus_reviews/factories/review_factory.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       show_identifier { false }
     end
 
+    trait :anonymous do
+      user { nil }
+    end
+
     trait :with_image do
       images {
         [

--- a/spec/requests/reviews_feed_spec.rb
+++ b/spec/requests/reviews_feed_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe '/reviews_feed' do
+  describe 'GET /.xml' do
+    subject { -> { get '/reviews_feed.xml' } }
+
+    let!(:review) { create(:review, :approved) }
+    let!(:anonymous_review) { create(:review, :approved, :anonymous) }
+
+    before do
+      Spree::Core::Engine.routes.default_url_options = { host: 'www.example.com' }
+    end
+
+    context 'when :enable_reviews_feed is explicitly enabled' do
+      before do
+        stub_spree_preferences(Spree::Reviews::Config, enable_reviews_feed: true)
+        Rails.application.reload_routes!
+      end
+
+      it 'responds with 200 OK' do
+        subject.call
+
+        expect(response.status).to eq(200)
+      end
+
+      it 'matches the expected snapshot' do
+        subject.call
+
+        expect(response.body).to eq(<<~XML)
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.google.com/shopping/reviews/schema/product/2.2/product_reviews.xsd">
+            <version>2.2</version>
+            <publisher>
+              <name/>
+              <favicon>/favicon.ico</favicon>
+            </publisher>
+            <reviews>
+              <review>
+                <review_id>#{anonymous_review.id}</review_id>
+                <reviewer>
+                  <name is_anonymous="true">#{anonymous_review.name}</name>
+                </reviewer>
+                <review_timestamp>#{anonymous_review.created_at.xmlschema}</review_timestamp>
+                <title>#{anonymous_review.title}</title>
+                <content>#{anonymous_review.review}</content>
+                <review_url type="group">#{spree.product_url(anonymous_review.product)}</review_url>
+                <ratings>
+                  <overall min="1" max="5">#{anonymous_review.rating}</overall>
+                </ratings>
+                <products>
+                  <product>
+                    <product_ids>
+                      <skus>
+                        <sku>#{anonymous_review.product.sku}</sku>
+                      </skus>
+                    </product_ids>
+                    <product_name>#{anonymous_review.product.name}</product_name>
+                    <product_url>#{spree.product_url(anonymous_review.product)}</product_url>
+                  </product>
+                </products>
+              </review>
+              <review>
+                <review_id>#{review.id}</review_id>
+                <reviewer>
+                  <name is_anonymous="false">#{review.name}</name>
+                  <reviewer_id>#{review.user.id}</reviewer_id>
+                </reviewer>
+                <review_timestamp>#{review.created_at.xmlschema}</review_timestamp>
+                <title>#{review.title}</title>
+                <content>#{review.review}</content>
+                <review_url type="group">#{spree.product_url(review.product)}</review_url>
+                <ratings>
+                  <overall min="1" max="5">#{review.rating}</overall>
+                </ratings>
+                <products>
+                  <product>
+                    <product_ids>
+                      <skus>
+                        <sku>#{review.product.sku}</sku>
+                      </skus>
+                    </product_ids>
+                    <product_name>#{review.product.name}</product_name>
+                    <product_url>#{spree.product_url(review.product)}</product_url>
+                  </product>
+                </products>
+              </review>
+            </reviews>
+          </feed>
+        XML
+      end
+    end
+
+    context 'when :enable_reviews_feed is not explicitly enabled' do
+      before { Rails.application.reload_routes! }
+
+      it 'does not find the route' do
+        expect(subject).to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements a default [Google Product Reviews feed](https://developers.google.com/product-review-feeds/schema), useful to showcase reviews in ads.