### PR TITLE
Allow solidus_support 0.4

### DIFF
--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.5'
+  s.add_dependency 'solidus_support', '~> 0.4'
 
   s.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
In stores that use e.g. the solidus_paypal_braintree extension which is
in a state right now that makes maintenance hard, we cannot upgrade to
the latest master of this extension because of this gem depending on
`solidus_support` `~> 0.5`.

I tested using 0.4 using the Gemfile, and it does work.