### PR TITLE
Revert "Replace deprected ` SolidusSupport::EngineExtensions::Decorat…

### DIFF
--- a/lib/solidus_reviews/engine.rb
+++ b/lib/solidus_reviews/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusReviews
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions
+    include SolidusSupport::EngineExtensions::Decorators
 
     isolate_namespace Spree
 


### PR DESCRIPTION
…ors` wiith ` SolidusSupport::EngineExtensions`"

This reverts commit 1cbf91f356224386be9e6c3053e6fe85734402e7.

This should not have been released as a minor version bump, since this breaks with solidus_support 0.4 - a version we still support.