### PR TITLE
Bump solidus_support to 0.5

### DIFF
--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.4'
+  s.add_dependency 'solidus_support', '~> 0.5'
 
   s.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
We remove a deprecated constant that breaks using this gem with solidus_support 0.4.