### PR TITLE
Fix Autoloading on Rails 7

### DIFF
--- a/config/initializers/load_preferences.rb
+++ b/config/initializers/load_preferences.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-module Spree
-  module Reviews
-    Config = Spree::ReviewsConfiguration.new
+Rails.application.reloader.to_prepare do
+  module Spree
+    module Reviews
+      Config = Spree::ReviewsConfiguration.new
+    end
   end
 end


### PR DESCRIPTION
Due to recently changes on Rails 7, we may facing error like this

```
in `<module:Reviews>': uninitialized constant Spree::ReviewsConfiguration (NameError)

    Config = Spree::ReviewsConfiguration.new
```

I think we should wrap in safe loading method to fix this