### PR TITLE
Ransack allowlists for Spree::Review

### DIFF
--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -27,6 +27,23 @@ class Spree::Review < ApplicationRecord
   scope :not_approved, -> { where(approved: false) }
   scope :default_approval_filter, -> { Spree::Reviews::Config[:include_unapproved_reviews] ? all : approved }
 
+  def self.ransackable_attributes(*)
+    [
+      "approved",
+      "name",
+      "review",
+      "title"
+    ]
+  end
+
+  def self.ransackable_associations(*)
+    [
+      "feedback_reviews",
+      "product",
+      "user"
+    ]
+  end
+
   def feedback_stars
     return 0 if feedback_reviews.size <= 0
 

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -123,6 +123,18 @@ describe Spree::Review do
     end
   end
 
+  describe '.ransackable_attributes' do
+    subject { described_class.ransackable_attributes }
+
+    it { is_expected.to contain_exactly("approved", "name", "review", "title") }
+  end
+
+  describe '.ransackable_associations' do
+    subject { described_class.ransackable_associations }
+
+    it { is_expected.to contain_exactly("feedback_reviews", "product", "user") }
+  end
+
   describe '#recalculate_product_rating' do
     let(:product) { create(:product) }
     let!(:review) { create(:review, product: product) }


### PR DESCRIPTION
We filter admin views for reviews with the ransack gem. Since version 4, Ransack mandates every filtered model to explicitly specify which attributes and associations should be "ransackable". This PR adds those allowlists.