### PR TITLE
Add deface dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,28 +14,28 @@ jobs:
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: "3.0"
+      ruby_version: "3.2"
     steps:
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: "3.0"
+      ruby_version: "3.2"
     steps:
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
-      ruby_version: "3.0"
+      ruby_version: "3.2"
     steps:
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests
   lint-code:
     executor:
       name: solidusio_extensions/sqlite-memory
-      ruby_version: "3.0"
+      ruby_version: "3.2"
     steps:
       - solidusio_extensions/lint-code
 

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'deface', ['>= 1.9.0', '< 2.0']
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.8'
 


### PR DESCRIPTION
We still use deface in this gem, so it must be a dependency - otherwise the sandbox won't build.