### PR TITLE
Replace deprecated `#ransackable_attributes` syntax

### DIFF
--- a/app/models/spree/feedback_review.rb
+++ b/app/models/spree/feedback_review.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Spree::FeedbackReview < ApplicationRecord
+class Spree::FeedbackReview < Spree::Base
   belongs_to :user, class_name: Spree.user_class.to_s, optional: true
 
   belongs_to :review, touch: true

--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -27,22 +27,8 @@ class Spree::Review < Spree::Base
   scope :not_approved, -> { where(approved: false) }
   scope :default_approval_filter, -> { Spree::Reviews::Config[:include_unapproved_reviews] ? all : approved }
 
-  def self.ransackable_attributes(*)
-    [
-      "approved",
-      "name",
-      "review",
-      "title"
-    ]
-  end
-
-  def self.ransackable_associations(*)
-    [
-      "feedback_reviews",
-      "product",
-      "user"
-    ]
-  end
+  self.allowed_ransackable_associations = %w[feedback_reviews product user]
+  self.allowed_ransackable_attributes = %w[approved name review title]
 
   def feedback_stars
     return 0 if feedback_reviews.size <= 0

--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Spree::Review < ApplicationRecord
+class Spree::Review < Spree::Base
   belongs_to :product, touch: true, optional: true
   belongs_to :user, class_name: Spree.user_class.to_s, optional: true
   has_many   :feedback_reviews, dependent: :destroy

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -126,7 +126,7 @@ describe Spree::Review do
   describe '.ransackable_attributes' do
     subject { described_class.ransackable_attributes }
 
-    it { is_expected.to contain_exactly("approved", "name", "review", "title") }
+    it { is_expected.to contain_exactly("id", "approved", "name", "review", "title") }
   end
 
   describe '.ransackable_associations' do


### PR DESCRIPTION
Ransack has deprecated the `#ransackable_attributes` method. This PR updates the syntax to use the `.allowed_ransackable_attributes` class method defined on `Spree::Base` instead.