### PR TITLE
Fix duplicate menu items bug

### DIFF
--- a/app/views/spree/admin/feedback_reviews/index.html.erb
+++ b/app/views/spree/admin/feedback_reviews/index.html.erb
@@ -6,8 +6,6 @@
 	<li><%= link_to I18n.t("spree.back_to_reviews"), admin_reviews_path %></li>
 <% end %>
 
-<% render 'spree/admin/shared/product_sub_menu' %>
-
 <% if @collection.any? %>
 	<table class="index">
 		<colgroup>

--- a/app/views/spree/admin/reviews/edit.html.erb
+++ b/app/views/spree/admin/reviews/edit.html.erb
@@ -2,8 +2,6 @@
 	<%= I18n.t("spree.editing_review_for_html", product_name: @review.product.name) %>
 <% end %>
 
-<% render 'spree/admin/shared/product_sub_menu' %>
-
 <%= form_for([:admin, @review]) do |f| %>
 	<div class="alpha eight columns">
 		<% unless @review.title.blank? %>

--- a/config/initializers/add_spree_reviews_to_menu.rb
+++ b/config/initializers/add_spree_reviews_to_menu.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.config.to_prepare do
+Rails.application.config.after_initialize do
   Spree::Backend::Config.configure do |config|
     config.menu_items = config.menu_items.map do |item|
       if item.label.to_sym == :settings

--- a/solidus_reviews.gemspec
+++ b/solidus_reviews.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'concurrent-ruby', '< 1.3.5'
   spec.add_dependency 'deface', ['>= 1.9.0', '< 2.0']
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.8'


### PR DESCRIPTION
This fixes a bug where the "Reviews" menu item would get added over and over again each time the Solidus app is reloaded in development mode.
    
I'm also removing references to the `_product_sub_menu` partial which is now deprecated.

![Screenshot 2024-10-23 at 13 50 31](https://github.com/user-attachments/assets/dc17361d-5628-45c5-98ae-9b9cc29563a8)