### PR TITLE
Do not limit concurrent-ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ else
   gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
 end
 
-# Needed for Rails 7.0
-gem 'concurrent-ruby', '< 1.3.5'
-
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.
 # See https://github.com/bundler/bundler/issues/6677


### PR DESCRIPTION
This was only needed temporarily for Solidus 4.1 and Solidus 4.2, as long as those gems didn't limit the dependency themselves.

Cf https://github.com/solidusio/solidus/pull/6077